### PR TITLE
Set max version in version file

### DIFF
--- a/GameData/ProbeControlRoom/ProbeControlRoom.version
+++ b/GameData/ProbeControlRoom/ProbeControlRoom.version
@@ -26,5 +26,11 @@
 		"MAJOR": 1,
 		"MINOR": 2,
 		"PATCH": 0
+	},
+	"KSP_VERSION_MAX":
+	{
+		"MAJOR": 1,
+		"MINOR": 2,
+		"PATCH": 2
 	}
 }


### PR DESCRIPTION
The version file indicates compatibility with KSP 1.2.0 and later. This is unlikely to be accurate since this mod contains DLLs, and users have reported that it doesn't work on current versions:

https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1270-bussard/&do=findComment&comment=3779968

This PR updates the version file to be compatible with KSP 1.2.0 through 1.2.2 only.